### PR TITLE
junit parallel

### DIFF
--- a/src/test/java/com/london/reboot/RestfulApplicationTests.java
+++ b/src/test/java/com/london/reboot/RestfulApplicationTests.java
@@ -1,6 +1,8 @@
 package com.london.reboot;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -16,6 +18,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Execution(ExecutionMode.CONCURRENT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")

--- a/src/test/java/com/london/reboot/controllers/UserControllerTest.java
+++ b/src/test/java/com/london/reboot/controllers/UserControllerTest.java
@@ -1,8 +1,9 @@
 package com.london.reboot.controllers;
 
-import com.london.reboot.TestRedisConfiguration;
 import com.london.reboot.domain.User;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.util.MimeTypeUtils.ALL_VALUE;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
+@Execution(ExecutionMode.CONCURRENT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")

--- a/src/test/java/com/london/reboot/service/SampleServiceTest.java
+++ b/src/test/java/com/london/reboot/service/SampleServiceTest.java
@@ -2,6 +2,8 @@ package com.london.reboot.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +12,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(SpringExtension.class)
 class SampleServiceTest {
 

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled=true


### PR DESCRIPTION
tests are failing because assertions rely on datastore state. can't be merged until tests are refactored